### PR TITLE
chore(skills): drop ast-grep

### DIFF
--- a/skills/ast-grep
+++ b/skills/ast-grep
@@ -1,1 +1,0 @@
-../../.agents/skills/ast-grep


### PR DESCRIPTION
Removes the ast-grep symlink — skill no longer needed.